### PR TITLE
feat: store data in sqlite database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+*.db

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "recharts": "^2.15.1",
     "tailwind-merge": "^3.0.1",
     "tailwindcss-animate": "^1.0.7",
-    "zod": "^3.24.2"
+    "zod": "^3.24.2",
+    "better-sqlite3": "^9.4.0"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -1,176 +1,134 @@
 'use server';
 
 import type { Position, PopulatedShift, Shift, User, Assembly, PopulatedAssembly } from '@/lib/types';
-import { initialUsers, initialPositions, initialAssemblies, initialShifts } from '@/lib/mock-data';
+import db from '@/lib/db';
 
-// --- In-memory data store ---
-let users: User[] = JSON.parse(JSON.stringify(initialUsers));
-let positions: Position[] = JSON.parse(JSON.stringify(initialPositions));
-let assemblies: Assembly[] = JSON.parse(JSON.stringify(initialAssemblies.map(a => {
-    const { volunteers, ...rest } = a;
-    return rest;
-})));
-let shifts: Shift[] = JSON.parse(JSON.stringify(initialShifts.map(s => {
-    const { position, volunteer, assembly, ...rest } = s;
-    return rest;
-})));
-
-
-const parseDatesInObject = <T extends { startTime?: any, endTime?: any, startDate?: any, endDate?: any }>(item: T): T => {
-    const newItem = { ...item };
-    if (item.startTime && typeof item.startTime === 'string') newItem.startTime = new Date(item.startTime);
-    if (item.endTime && typeof item.endTime === 'string') newItem.endTime = new Date(item.endTime);
-    if (item.startDate && typeof item.startDate === 'string') newItem.startDate = new Date(item.startDate);
-    if (item.endDate && typeof item.endDate === 'string') newItem.endDate = new Date(item.endDate);
-    return newItem;
-};
-
-const parseDatesInArray = <T extends { startTime?: any, endTime?: any, startDate?: any, endDate?: any }>(items: T[]): T[] => {
-    return items.map(parseDatesInObject);
-};
-
-shifts = parseDatesInArray(shifts);
-assemblies = parseDatesInArray(assemblies);
-
-// Helper to generate IDs
 const generateId = () => Math.random().toString(36).substr(2, 9);
 
-// --- API Functions ---
+const getAssemblyVolunteerIds = (assemblyId: string): string[] => {
+  const rows = db.prepare('SELECT volunteerId FROM assembly_volunteers WHERE assemblyId = ?').all(assemblyId) as { volunteerId: string }[];
+  return rows.map(r => r.volunteerId);
+};
 
 // Users
 export const getUsers = async (): Promise<User[]> => {
-    return JSON.parse(JSON.stringify(users));
+  return db.prepare('SELECT * FROM users').all() as User[];
 };
 
 export const getUser = async (id: string): Promise<User | null> => {
-    const user = users.find(u => u.id === id);
-    return user ? JSON.parse(JSON.stringify(user)) : null;
-}
+  const row = db.prepare('SELECT * FROM users WHERE id = ?').get(id) as User | undefined;
+  return row || null;
+};
 
 export const getUserByEmail = async (email: string): Promise<User | undefined> => {
-    const user = users.find(u => u.email === email);
-    return user ? JSON.parse(JSON.stringify(user)) : undefined;
-}
+  const row = db.prepare('SELECT * FROM users WHERE email = ?').get(email) as User | undefined;
+  return row;
+};
 
 // Positions
 export const getPositions = async (): Promise<Position[]> => {
-    return JSON.parse(JSON.stringify(positions));
+  return db.prepare('SELECT * FROM positions').all() as Position[];
 };
 
 // Assemblies
-export const getPopulatedAssemblies = async (): Promise<PopulatedAssembly[]> => {
-    const populatedAssemblies = assemblies.map(assembly => {
-        const assemblyVolunteers = users.filter(user => assembly.volunteerIds.includes(user.id));
-        return {
-            ...assembly,
-            volunteers: assemblyVolunteers
-        };
-    });
-    // Simulating the server-to-client data transfer by stringifying and then parsing dates back.
-    const stringified = JSON.stringify(populatedAssemblies);
-    return parseDatesInArray(JSON.parse(stringified));
-}
-
 export const getAssemblies = async (): Promise<Assembly[]> => {
-    const sorted = assemblies.sort((a,b) => new Date(b.startDate).getTime() - new Date(a.startDate).getTime());
-    // Simulating the server-to-client data transfer by stringifying and then parsing dates back.
-    const stringified = JSON.stringify(sorted);
-    return parseDatesInArray(JSON.parse(stringified));
-}
+  const rows = db.prepare('SELECT * FROM assemblies ORDER BY startDate DESC').all() as any[];
+  return rows.map(r => ({
+    id: r.id,
+    title: r.title,
+    startDate: new Date(r.startDate),
+    endDate: new Date(r.endDate),
+    volunteerIds: getAssemblyVolunteerIds(r.id),
+    type: r.type
+  }));
+};
+
+export const getPopulatedAssemblies = async (): Promise<PopulatedAssembly[]> => {
+  const assemblies = await getAssemblies();
+  const stmt = db.prepare('SELECT u.* FROM users u JOIN assembly_volunteers av ON u.id = av.volunteerId WHERE av.assemblyId = ?');
+  return assemblies.map(a => ({
+    ...a,
+    volunteers: stmt.all(a.id) as User[]
+  }));
+};
 
 // Shifts
 export const getPopulatedShifts = async (): Promise<PopulatedShift[]> => {
-    const populated = shifts.map(shift => {
-        const position = positions.find(p => p.id === shift.positionId);
-        const assembly = assemblies.find(a => a.id === shift.assemblyId);
-        if (!position || !assembly) return null;
+  const rows = db.prepare(`
+    SELECT s.*, p.name as pName, p.description as pDescription, p.iconName as pIconName,
+           a.title as aTitle, a.startDate as aStartDate, a.endDate as aEndDate, a.type as aType,
+           u.id as uId, u.name as uName, u.phone as uPhone, u.email as uEmail, u.role as uRole, u.passwordHash as uPasswordHash
+    FROM shifts s
+    JOIN positions p ON s.positionId = p.id
+    JOIN assemblies a ON s.assemblyId = a.id
+    LEFT JOIN users u ON s.volunteerId = u.id
+  `).all() as any[];
 
-        return {
-            ...shift,
-            position,
-            volunteer: shift.volunteerId ? users.find(u => u.id === shift.volunteerId) || null : null,
-            assembly,
-        };
-    }).filter((s): s is PopulatedShift => s !== null);
-    
-    const sorted = populated.sort((a,b) => new Date(a.startTime).getTime() - new Date(b.startTime).getTime());
-    
-    // Simulating the server-to-client data transfer by stringifying and then parsing dates back.
-    const stringified = JSON.stringify(sorted);
-    return parseDatesInArray(JSON.parse(stringified));
+  const shifts = rows.map(r => ({
+    id: r.id,
+    positionId: r.positionId,
+    volunteerId: r.volunteerId,
+    startTime: new Date(r.startTime),
+    endTime: new Date(r.endTime),
+    assemblyId: r.assemblyId,
+    rejectionReason: r.rejectionReason || null,
+    rejectedBy: r.rejectedBy || null,
+    position: { id: r.positionId, name: r.pName, description: r.pDescription, iconName: r.pIconName },
+    volunteer: r.volunteerId ? { id: r.uId, name: r.uName, phone: r.uPhone, email: r.uEmail, role: r.uRole, passwordHash: r.uPasswordHash } : null,
+    assembly: { id: r.assemblyId, title: r.aTitle, startDate: new Date(r.aStartDate), endDate: new Date(r.aEndDate), volunteerIds: getAssemblyVolunteerIds(r.assemblyId), type: r.aType }
+  })) as PopulatedShift[];
+
+  return shifts.sort((a,b) => a.startTime.getTime() - b.startTime.getTime());
 };
 
-// --- CRUD Operations (for Server Actions) ---
+// CRUD Operations
 export const addUser = async (userData: Omit<User, 'id' | 'passwordHash'> & { password?: string }) => {
-    const newUser: User = {
-        id: generateId(),
-        ...userData,
-        passwordHash: userData.password || 'password'
-    };
-    users.push(newUser);
-    return newUser;
+  const newUser: User = { id: generateId(), ...userData, passwordHash: userData.password || 'password' };
+  db.prepare('INSERT INTO users (id, name, phone, email, role, passwordHash) VALUES (@id, @name, @phone, @email, @role, @passwordHash)').run(newUser);
+  return newUser;
 };
 
 export const updateUser = async (userId: string, userData: Partial<Omit<User, 'id' | 'passwordHash'>>) => {
-    const userIndex = users.findIndex(u => u.id === userId);
-    if(userIndex > -1) {
-        users[userIndex] = { ...users[userIndex], ...userData };
-    }
-    return users[userIndex];
-}
+  const sets = Object.keys(userData).map(k => `${k} = @${k}`).join(', ');
+  db.prepare(`UPDATE users SET ${sets} WHERE id = @id`).run({ id: userId, ...userData });
+  return getUser(userId);
+};
 
 export const addPosition = async (positionData: Omit<Position, 'id'>) => {
-    const newPosition: Position = { id: generateId(), ...positionData };
-    positions.push(newPosition);
-    return newPosition;
+  const newPosition: Position = { id: generateId(), ...positionData };
+  db.prepare('INSERT INTO positions (id, name, description, iconName) VALUES (@id, @name, @description, @iconName)').run(newPosition);
+  return newPosition;
 };
 
 export const addAssembly = async (assemblyData: Omit<Assembly, 'id' | 'volunteerIds'>) => {
-    const newAssembly: Assembly = {
-        id: generateId(),
-        ...assemblyData,
-        volunteerIds: [],
-    };
-    assemblies.push(newAssembly);
-    return newAssembly;
+  const newAssembly: Assembly = { id: generateId(), ...assemblyData, volunteerIds: [] };
+  db.prepare('INSERT INTO assemblies (id, title, startDate, endDate, type) VALUES (@id, @title, @startDate, @endDate, @type)').run({ ...newAssembly, startDate: newAssembly.startDate.toISOString(), endDate: newAssembly.endDate.toISOString() });
+  return newAssembly;
 };
 
 export const updateAssembly = async (assemblyId: string, assemblyData: Partial<Omit<Assembly, 'id'>>) => {
-    const index = assemblies.findIndex(a => a.id === assemblyId);
-    if (index !== -1) {
-        assemblies[index] = { ...assemblies[index], ...assemblyData };
-    }
+  const data: any = { ...assemblyData };
+  if (data.startDate) data.startDate = data.startDate.toISOString();
+  if (data.endDate) data.endDate = data.endDate.toISOString();
+  const sets = Object.keys(data).map(k => `${k} = @${k}`).join(', ');
+  if (sets) db.prepare(`UPDATE assemblies SET ${sets} WHERE id = @id`).run({ id: assemblyId, ...data });
 };
 
 export const associateVolunteerToAssembly = async (assemblyId: string, volunteerId: string) => {
-    const assembly = assemblies.find(a => a.id === assemblyId);
-    if (assembly && !assembly.volunteerIds.includes(volunteerId)) {
-        assembly.volunteerIds.push(volunteerId);
-    }
-}
+  db.prepare('INSERT OR IGNORE INTO assembly_volunteers (assemblyId, volunteerId) VALUES (?, ?)').run(assemblyId, volunteerId);
+};
 
 export const addShift = async (shiftData: Omit<Shift, 'id' | 'rejectionReason' | 'rejectedBy'>) => {
-    const newShift: Shift = { id: generateId(), ...shiftData };
-    shifts.push(newShift);
-    return newShift;
+  const newShift: Shift = { id: generateId(), ...shiftData };
+  db.prepare('INSERT INTO shifts (id, positionId, volunteerId, startTime, endTime, assemblyId) VALUES (@id, @positionId, @volunteerId, @startTime, @endTime, @assemblyId)').run({ ...newShift, startTime: newShift.startTime.toISOString(), endTime: newShift.endTime.toISOString() });
+  return newShift;
 };
 
 export const updateShift = async (shiftId: string, volunteerId: string | null) => {
-    const shift = shifts.find(s => s.id === shiftId);
-    if (shift) {
-        shift.volunteerId = volunteerId;
-        delete shift.rejectionReason;
-        delete shift.rejectedBy;
-    }
+  db.prepare('UPDATE shifts SET volunteerId = ?, rejectionReason = NULL, rejectedBy = NULL WHERE id = ?').run(volunteerId, shiftId);
 };
 
 export const rejectShift = async (shiftId: string, volunteerId: string, reason: string | null) => {
-    const shift = shifts.find(s => s.id === shiftId);
-    if (!shift || !volunteerId) {
-        throw new Error('Cannot reject a shift without a volunteer.');
-    }
-    
-    shift.volunteerId = null;
-    shift.rejectionReason = reason || 'Sin motivo';
-    shift.rejectedBy = volunteerId;
-}
+  if (!volunteerId) throw new Error('Cannot reject a shift without a volunteer.');
+  db.prepare('UPDATE shifts SET volunteerId = NULL, rejectionReason = ?, rejectedBy = ? WHERE id = ?').run(reason || 'Sin motivo', volunteerId, shiftId);
+};

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,0 +1,64 @@
+import Database from 'better-sqlite3';
+import { initialUsers, initialPositions, initialAssemblies, initialShifts } from '@/lib/mock-data';
+
+const db = new Database('data.db');
+
+db.exec(`
+CREATE TABLE IF NOT EXISTS users (
+  id TEXT PRIMARY KEY,
+  name TEXT,
+  phone TEXT,
+  email TEXT UNIQUE,
+  role TEXT,
+  passwordHash TEXT
+);
+CREATE TABLE IF NOT EXISTS positions (
+  id TEXT PRIMARY KEY,
+  name TEXT,
+  description TEXT,
+  iconName TEXT
+);
+CREATE TABLE IF NOT EXISTS assemblies (
+  id TEXT PRIMARY KEY,
+  title TEXT,
+  startDate TEXT,
+  endDate TEXT,
+  type TEXT
+);
+CREATE TABLE IF NOT EXISTS assembly_volunteers (
+  assemblyId TEXT,
+  volunteerId TEXT,
+  PRIMARY KEY (assemblyId, volunteerId)
+);
+CREATE TABLE IF NOT EXISTS shifts (
+  id TEXT PRIMARY KEY,
+  positionId TEXT,
+  volunteerId TEXT,
+  startTime TEXT,
+  endTime TEXT,
+  assemblyId TEXT,
+  rejectionReason TEXT,
+  rejectedBy TEXT
+);
+`);
+
+const userCount = db.prepare('SELECT COUNT(*) as count FROM users').get().count as number;
+if (userCount === 0) {
+  const insertUser = db.prepare('INSERT INTO users (id, name, phone, email, role, passwordHash) VALUES (@id, @name, @phone, @email, @role, @passwordHash)');
+  initialUsers.forEach(u => insertUser.run(u));
+
+  const insertPosition = db.prepare('INSERT INTO positions (id, name, description, iconName) VALUES (@id, @name, @description, @iconName)');
+  initialPositions.forEach(p => insertPosition.run(p));
+
+  const insertAssembly = db.prepare('INSERT INTO assemblies (id, title, startDate, endDate, type) VALUES (@id, @title, @startDate, @endDate, @type)');
+  const insertAV = db.prepare('INSERT INTO assembly_volunteers (assemblyId, volunteerId) VALUES (@assemblyId, @volunteerId)');
+  initialAssemblies.forEach(a => {
+    insertAssembly.run({ ...a, startDate: a.startDate.toISOString(), endDate: a.endDate.toISOString() });
+    a.volunteerIds.forEach(v => insertAV.run({ assemblyId: a.id, volunteerId: v }));
+  });
+
+  const insertShift = db.prepare('INSERT INTO shifts (id, positionId, volunteerId, startTime, endTime, assemblyId) VALUES (@id, @positionId, @volunteerId, @startTime, @endTime, @assemblyId)');
+  initialShifts.forEach(s => insertShift.run({ ...s, startTime: s.startTime.toISOString(), endTime: s.endTime.toISOString() }));
+}
+
+export default db;

--- a/src/types/better-sqlite3.d.ts
+++ b/src/types/better-sqlite3.d.ts
@@ -1,0 +1,1 @@
+declare module 'better-sqlite3';


### PR DESCRIPTION
## Summary
- persist users, positions, assemblies and shifts using SQLite instead of in-memory arrays
- add better-sqlite3 dependency and ignore generated database files

## Testing
- `npm run lint` *(fails: requires interactive configuration)*
- `npm run typecheck` *(fails: existing type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a1dff627ec832cae18901060116d66