### PR TITLE
feat: persist conversations in sqlite

### DIFF
--- a/src/lib/mock-data.ts
+++ b/src/lib/mock-data.ts
@@ -1,4 +1,4 @@
-import type { Position, PopulatedShift, User, PopulatedAssembly, Shift, Assembly } from '@/lib/types';
+import type { Position, PopulatedShift, User, PopulatedAssembly, Shift, Assembly, Conversation, Message } from '@/lib/types';
 
 export const initialUsers: User[] = [
   { id: '1', name: 'Admin User', phone: '123-456-7890', email: 'admin@example.com', role: 'admin', passwordHash: 'adminpassword' },
@@ -137,4 +137,29 @@ export const initialShifts: PopulatedShift[] = [
       assemblyId: 'a1',
       assembly: findAssembly('a1'),
     },
+];
+
+export const initialConversations: Conversation[] = [
+  {
+    id: 'c1',
+    name: null,
+    participantIds: ['1', '2'],
+  },
+];
+
+export const initialMessages: Message[] = [
+  {
+    id: 'm1',
+    conversationId: 'c1',
+    senderId: '1',
+    text: 'Hola Andrés, ¿cómo estás?',
+    timestamp: new Date('2024-07-01T10:00:00'),
+  },
+  {
+    id: 'm2',
+    conversationId: 'c1',
+    senderId: '2',
+    text: 'Todo bien, ¡gracias!',
+    timestamp: new Date('2024-07-01T10:05:00'),
+  },
 ];

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -45,3 +45,23 @@ export interface PopulatedShift extends Omit<Shift, 'positionId' | 'volunteerId'
   volunteer: User | null; // The currently assigned volunteer
   assembly: Assembly;
 }
+
+export interface Message {
+  id: string;
+  conversationId: string;
+  senderId: string;
+  text: string;
+  timestamp: Date;
+}
+
+export interface Conversation {
+  id: string;
+  name: string | null;
+  participantIds: string[];
+  lastMessage?: Message;
+}
+
+export interface PopulatedConversation extends Conversation {
+  participants: User[];
+  messages: Message[];
+}


### PR DESCRIPTION
## Summary
- add Conversation and Message types
- store conversations and messages in sqlite with initial seed data
- expose helpers to fetch conversations, populated conversations, and append messages

## Testing
- `npm run lint` *(fails: prompts for configuration)*
- `npm run typecheck` *(fails: various TS errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68a206ce8030832c8d9aad2cce50f200